### PR TITLE
docker deploy got removed on release v20.10. Replaced with docker sta…

### DIFF
--- a/tsuru/installer/compose.go
+++ b/tsuru/installer/compose.go
@@ -43,7 +43,7 @@ func composeDeploy(c ServiceCluster, installConfig *InstallOpts) error {
 		return fmt.Errorf("failed to write remote file: %s", err)
 	}
 	fmt.Print("Deploying compose file in cluster manager...\n")
-	output, err := manager.Host.RunSSHCommand("sudo docker deploy -c /etc/tsuru/compose.yml tsuru")
+	output, err := manager.Host.RunSSHCommand("sudo docker stack deploy -c /etc/tsuru/compose.yml tsuru")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
docker deploy got removed on release v20.10. Replaced with docker stack deploy and the same arguments - Reference: https://docs.docker.com/engine/deprecated/#top-level-docker-deploy-subcommand-experimental